### PR TITLE
applied namespace

### DIFF
--- a/src/Ginq.php
+++ b/src/Ginq.php
@@ -21,7 +21,7 @@ require_once dirname(__FILE__) . "/Ginq/Lookup.php";
  * Ginq
  * @package Ginq
  */
-class Ginq implements IteratorAggregate
+class Ginq implements \IteratorAggregate
 {
     protected $it = null;
 
@@ -29,12 +29,12 @@ class Ginq implements IteratorAggregate
 
     public static function useIterator() {
         require_once dirname(__FILE__) . "/Ginq/IterProviderIterImpl.php";
-        self::$gen = new IterProviderIterImpl();
+        self::$gen = new Ginq\IterProviderIterImpl();
     }
 
     public static function useGenerator() {
         require_once dirname(__FILE__) . "/Ginq/IterProviderGenImpl.php";
-        self::$gen = new IterProviderGenImpl();
+        self::$gen = new Ginq\IterProviderGenImpl();
     }
 
     protected function __construct($it)
@@ -86,7 +86,7 @@ class Ginq implements IteratorAggregate
     {
         $arr = array();
         foreach ($this->it as $k => $x) {
-            if ($x instanceof Iterator || $x instanceof IteratorAggregate) {
+            if ($x instanceof \Iterator || $x instanceof \IteratorAggregate) {
                 $arr[$k] = self::from($x)->toArrayRec();
             } else {
                 $arr[$k] = $x;
@@ -201,7 +201,7 @@ class Ginq implements IteratorAggregate
         if ($xs instanceof Ginq) {
             return $xs;
         } else {
-            return new Ginq(iter($xs));
+            return new Ginq(Ginq\iter($xs));
         }
     }
 
@@ -276,7 +276,7 @@ class Ginq implements IteratorAggregate
     {
         $outerKeySelector = self::_parse_selector($outerKeySelector);
         $innerKeySelector = self::_parse_selector($innerKeySelector);
-        $innerLookup = Lookup::from($inner, $innerKeySelector);
+        $innerLookup = Ginq\Lookup::from($inner, $innerKeySelector);
         return $this->selectMany(
             function($outer, $outerKey) use ($innerLookup, $outerKeySelector) {
                 return $innerLookup->get(
@@ -291,7 +291,7 @@ class Ginq implements IteratorAggregate
     {
         return self::from(self::$gen->zip(
             $this->it,
-            iter($rhs),
+            Ginq\iter($rhs),
             self::_parse_join_selector($joinSelector))
         );
     }

--- a/src/Ginq/IterProvider.php
+++ b/src/Ginq/IterProvider.php
@@ -13,6 +13,7 @@
  * @license    MIT License (http://www.opensource.org/licenses/mit-license.php)
  * @package    Ginq
  */
+namespace Ginq;
 
 /**
  * IterProvider

--- a/src/Ginq/IterProviderGenImpl.php
+++ b/src/Ginq/IterProviderGenImpl.php
@@ -13,6 +13,7 @@
  * @license    MIT License (http://www.opensource.org/licenses/mit-license.php)
  * @package    Ginq
  */
+namespace Ginq;
 
 require_once dirname(__FILE__) . "/IterProvider.php";
 require_once dirname(__FILE__) . "/Lookup.php";

--- a/src/Ginq/IterProviderIterImpl.php
+++ b/src/Ginq/IterProviderIterImpl.php
@@ -13,6 +13,7 @@
  * @license    MIT License (http://www.opensource.org/licenses/mit-license.php)
  * @package    Ginq
  */
+namespace Ginq;
 
 $dir = dirname(__FILE__);
 

--- a/src/Ginq/Iterator/ConcatIterator.php
+++ b/src/Ginq/Iterator/ConcatIterator.php
@@ -13,12 +13,13 @@
  * @license    MIT License (http://www.opensource.org/licenses/mit-license.php)
  * @package    Ginq
  */
+namespace Ginq;
 
 /**
  * ConcatIterator
  * @package Ginq
  */
-class ConcatIterator implements Iterator
+class ConcatIterator implements \Iterator
 {
     private $it0;
     private $it1;

--- a/src/Ginq/Iterator/CycleIterator.php
+++ b/src/Ginq/Iterator/CycleIterator.php
@@ -13,12 +13,13 @@
  * @license    MIT License (http://www.opensource.org/licenses/mit-license.php)
  * @package    Ginq
  */
+namespace Ginq;
 
 /**
  * CycleIterator
  * @package Ginq
  */
-class CycleIterator implements Iterator
+class CycleIterator implements \Iterator
 {
     private $i;
     private $it;

--- a/src/Ginq/Iterator/DropIterator.php
+++ b/src/Ginq/Iterator/DropIterator.php
@@ -13,12 +13,13 @@
  * @license    MIT License (http://www.opensource.org/licenses/mit-license.php)
  * @package    Ginq
  */
+namespace Ginq;
 
 /**
  * DropIterator
  * @package Ginq
  */
-class DropIterator implements Iterator
+class DropIterator implements \Iterator
 {
     private $it;
     private $n;

--- a/src/Ginq/Iterator/DropWhileIterator.php
+++ b/src/Ginq/Iterator/DropWhileIterator.php
@@ -13,6 +13,7 @@
  * @license    MIT License (http://www.opensource.org/licenses/mit-license.php)
  * @package    Ginq
  */
+namespace Ginq;
 
 require_once dirname(dirname(__FILE__)) . "/iter.php";
 
@@ -20,7 +21,7 @@ require_once dirname(dirname(__FILE__)) . "/iter.php";
  * DropWhileIterator
  * @package Ginq
  */
-class DropWhileIterator implements Iterator
+class DropWhileIterator implements \Iterator
 {
     private $it;
     private $predicate;

--- a/src/Ginq/Iterator/GroupByIterator.php
+++ b/src/Ginq/Iterator/GroupByIterator.php
@@ -13,6 +13,7 @@
  * @license    MIT License (http://www.opensource.org/licenses/mit-license.php)
  * @package    Ginq
  */
+namespace Ginq;
 
 require_once dirname(dirname(__FILE__)) . "/iter.php";
 require_once dirname(dirname(__FILE__)) . "/Lookup.php";
@@ -21,7 +22,7 @@ require_once dirname(dirname(__FILE__)) . "/Lookup.php";
  * GroupByIterator
  * @package Ginq
  */
-class GroupByIterator implements Iterator
+class GroupByIterator implements \Iterator
 {
     private $keySelector;
     private $elementSelector;

--- a/src/Ginq/Iterator/RangeInfIterator.php
+++ b/src/Ginq/Iterator/RangeInfIterator.php
@@ -13,12 +13,13 @@
  * @license    MIT License (http://www.opensource.org/licenses/mit-license.php)
  * @package    Ginq
  */
+namespace Ginq;
 
 /**
  * RangeInfIterator
  * @package Ginq
  */
-class RangeInfIterator implements Iterator
+class RangeInfIterator implements \Iterator
 {
     private $start;
     private $step;

--- a/src/Ginq/Iterator/RangeIterator.php
+++ b/src/Ginq/Iterator/RangeIterator.php
@@ -13,12 +13,13 @@
  * @license    MIT License (http://www.opensource.org/licenses/mit-license.php)
  * @package    Ginq
  */
+namespace Ginq;
 
 /**
  * RangeIterator
  * @package Ginq
  */
-class RangeIterator implements Iterator
+class RangeIterator implements \Iterator
 {
     private $start;
     private $stop;

--- a/src/Ginq/Iterator/RepeatIterator.php
+++ b/src/Ginq/Iterator/RepeatIterator.php
@@ -13,12 +13,13 @@
  * @license    MIT License (http://www.opensource.org/licenses/mit-license.php)
  * @package    Ginq
  */
+namespace Ginq;
 
 /**
  * RepeatIterator
  * @package Ginq
  */
-class RepeatIterator implements Iterator
+class RepeatIterator implements \Iterator
 {
     private $i;
     private $x;

--- a/src/Ginq/Iterator/SelectIterator.php
+++ b/src/Ginq/Iterator/SelectIterator.php
@@ -13,6 +13,7 @@
  * @license    MIT License (http://www.opensource.org/licenses/mit-license.php)
  * @package    Ginq
  */
+namespace Ginq;
 
 require_once dirname(dirname(__FILE__)) . "/iter.php";
 
@@ -20,7 +21,7 @@ require_once dirname(dirname(__FILE__)) . "/iter.php";
  * SelectIterator
  * @package Ginq
  */
-class SelectIterator implements Iterator
+class SelectIterator implements \Iterator
 {
     private $it;
     private $selector;

--- a/src/Ginq/Iterator/SelectManyIterator.php
+++ b/src/Ginq/Iterator/SelectManyIterator.php
@@ -13,6 +13,7 @@
  * @license    MIT License (http://www.opensource.org/licenses/mit-license.php)
  * @package    Ginq
  */
+namespace Ginq;
 
 require_once dirname(dirname(__FILE__)) . "/iter.php";
 
@@ -20,7 +21,7 @@ require_once dirname(dirname(__FILE__)) . "/iter.php";
  * SelectManyIterator
  * @package Ginq
  */
-class SelectManyIterator implements Iterator
+class SelectManyIterator implements \Iterator
 {
     private $manySelector;
 

--- a/src/Ginq/Iterator/SelectManyWithJoinIterator.php
+++ b/src/Ginq/Iterator/SelectManyWithJoinIterator.php
@@ -13,6 +13,7 @@
  * @license    MIT License (http://www.opensource.org/licenses/mit-license.php)
  * @package    Ginq
  */
+namespace Ginq;
 
 require_once dirname(dirname(__FILE__)) . "/iter.php";
 
@@ -20,7 +21,7 @@ require_once dirname(dirname(__FILE__)) . "/iter.php";
  * SelectManyWithJoinIterator
  * @package Ginq
  */
-class SelectManyWithJoinIterator implements Iterator
+class SelectManyWithJoinIterator implements \Iterator
 {
     private $manySelector;
     private $joinSelector;

--- a/src/Ginq/Iterator/TakeIterator.php
+++ b/src/Ginq/Iterator/TakeIterator.php
@@ -13,12 +13,13 @@
  * @license    MIT License (http://www.opensource.org/licenses/mit-license.php)
  * @package    Ginq
  */
+namespace Ginq;
 
 /**
  * TakeIterator
  * @package Ginq
  */
-class TakeIterator implements Iterator
+class TakeIterator implements \Iterator
 {
     private $it;
     private $n;

--- a/src/Ginq/Iterator/TakeWhileIterator.php
+++ b/src/Ginq/Iterator/TakeWhileIterator.php
@@ -13,6 +13,7 @@
  * @license    MIT License (http://www.opensource.org/licenses/mit-license.php)
  * @package    Ginq
  */
+namespace Ginq;
 
 require_once dirname(dirname(__FILE__)) . "/iter.php";
 
@@ -20,7 +21,7 @@ require_once dirname(dirname(__FILE__)) . "/iter.php";
  * TakeWhileIterator
  * @package Ginq
  */
-class TakeWhileIterator implements Iterator
+class TakeWhileIterator implements \Iterator
 {
     private $it;
     private $predicate;

--- a/src/Ginq/Iterator/WhereIterator.php
+++ b/src/Ginq/Iterator/WhereIterator.php
@@ -13,6 +13,7 @@
  * @license    MIT License (http://www.opensource.org/licenses/mit-license.php)
  * @package    Ginq
  */
+namespace Ginq;
 
 require_once dirname(dirname(__FILE__)) . "/iter.php";
 
@@ -20,7 +21,7 @@ require_once dirname(dirname(__FILE__)) . "/iter.php";
  * WhereIterator
  * @package Ginq
  */
-class WhereIterator implements Iterator
+class WhereIterator implements \Iterator
 {
     private $it;
     private $predicate;

--- a/src/Ginq/Iterator/ZeroIterator.php
+++ b/src/Ginq/Iterator/ZeroIterator.php
@@ -13,12 +13,13 @@
  * @license    MIT License (http://www.opensource.org/licenses/mit-license.php)
  * @package    Ginq
  */
+namespace Ginq;
 
 /**
  * ZeroIterator
  * @package Ginq
  */
-class ZeroIterator implements Iterator
+class ZeroIterator implements \Iterator
 {
     public function current()
     {

--- a/src/Ginq/Iterator/ZipIterator.php
+++ b/src/Ginq/Iterator/ZipIterator.php
@@ -13,12 +13,13 @@
  * @license    MIT License (http://www.opensource.org/licenses/mit-license.php)
  * @package    Ginq
  */
+namespace Ginq;
 
 /**
  * ZipIterator
  * @package Ginq
  */
-class ZipIterator implements Iterator
+class ZipIterator implements \Iterator
 {
     private $joinSelector;
 

--- a/src/Ginq/Lookup.php
+++ b/src/Ginq/Lookup.php
@@ -13,6 +13,7 @@
  * @license    MIT License (http://www.opensource.org/licenses/mit-license.php)
  * @package    Ginq
  */
+namespace Ginq;
 
 require_once dirname(__FILE__) . "/iter.php";
 
@@ -20,7 +21,7 @@ require_once dirname(__FILE__) . "/iter.php";
  * Lookup
  * @package Ginq
  */
-class Lookup implements IteratorAggregate
+class Lookup implements \IteratorAggregate
 {
     private $table = null;
 

--- a/src/Ginq/iter.php
+++ b/src/Ginq/iter.php
@@ -13,6 +13,7 @@
  * @license    MIT License (http://www.opensource.org/licenses/mit-license.php)
  * @package    Ginq
  */
+namespace Ginq;
 
 /**
  * iter
@@ -20,15 +21,15 @@
  */
 function iter($xs)
 {
-    if ($xs instanceof Iterator) {
+    if ($xs instanceof \Iterator) {
         return $xs;
-    } else if ($xs instanceof IteratorAggregate) {
+    } else if ($xs instanceof \IteratorAggregate) {
         return $xs->getIterator();
     } else if (is_array($xs)) {
-        return new ArrayIterator($xs);
+        return new \ArrayIterator($xs);
     } else {
         $t = gettype($xs);
-        throw new InvalidArgumentException("'$t' object is not iterable");
+        throw new \InvalidArgumentException("'$t' object is not iterable");
     }
 }
 


### PR DESCRIPTION
In order to prevent global spaces, low-level classes have been encapsulated in namespace.
