### PR TITLE
Plugin feature

### DIFF
--- a/src/Ginq.php
+++ b/src/Ginq.php
@@ -364,6 +364,15 @@ class Ginq implements IteratorAggregate
         }
     }
 
+    public function __call($name, $args) {
+        if (isset(self::$registeredFunctions[$name])) {
+            call_user_func_array(
+                self::$registeredFunctions[$name], 
+                array_merge(array($this), $args)
+            );
+        }
+    }
+
     private static $registeredFunctions = array();
 
     public static function register($className) {
@@ -373,8 +382,11 @@ class Ginq implements IteratorAggregate
             ->where(function ($m) { return $m->isPublic(); })
             ->where(function ($m) {
                 $p = Ginq::from($m->getParameters())->first(false);
+                if ($p === false) return false;
 
-                return ($p !== false) and $p->getClass()->implementsInterface('Iterator');
+                $c = $p->getClass();
+
+                return ($c->getName() === 'Ginq') or $c->isSubclassOf('Ginq');
             })
             ->select(function ($m) { return $m->getName(); })
             ->toArray()

--- a/test/GinqPluginTest.php
+++ b/test/GinqPluginTest.php
@@ -31,7 +31,7 @@ class GinqPluginTest extends PHPUnit_Framework_TestCase {
 
     	$sum = 0;
     	Ginq::range(1, 10)
-    		->each(function ($v) {
+    		->each(function ($v) use(&$sum) {
     			$sum += $v;
     		})
    		;
@@ -45,7 +45,13 @@ class SamplePlugin {
 		Ginq::register(get_called_class());
 	}
 
-	public static function each(\Iterator $iter, $selector) {
+	public static function each(\Ginq $self, $selector) {
+		if (is_null($selector)) {
+			throw new \ArgumentException('must be passed closure as 2nd argument.');
+		}
 
+		foreach ($self as $k => $v) {
+			$selector($v, $k);
+		}
 	}
 }


### PR DESCRIPTION
Add Plugin feature.

This feture will result in separating the method alias or the combination method.

usage
1. Prepare static method baring the Ginq instance at 1st arg at least.
2. At register method (usually named as register) in plugin class, call Ginq::register(<class name>).

Refer to unit test for more information.
