### PR TITLE
Some classes are moved into Ginq namespace, then require_once removed.

### DIFF
--- a/src/Ginq.php
+++ b/src/Ginq.php
@@ -25,6 +25,8 @@ use Ginq\Predicate\PredicateParser;
 use Ginq\Util\IteratorUtil;
 use Ginq\Comparer\ReverseComparer;
 use Ginq\Comparer\ProjectionComparer;
+use Ginq\OrderedGinq;
+use Ginq\GroupingGinq;
 
 /**
  * Ginq
@@ -973,7 +975,3 @@ class Ginq implements IteratorAggregate
 Ginq::_registerAutoloadFunction();
 
 Ginq::useIterator();
-
-require_once "OrderedGinq.php";
-require_once "GroupingGinq.php";
-

--- a/src/Ginq/GroupingGinq.php
+++ b/src/Ginq/GroupingGinq.php
@@ -14,6 +14,8 @@
  * @package    Ginq
  */
 
+namespace Ginq;
+
 use Ginq\Core\Selector;
 use Ginq\Core\JoinSelector;
 use Ginq\Core\Comparer;
@@ -26,7 +28,7 @@ use Ginq\Comparer\ReverseComparer;
 use Ginq\Comparer\ProjectionComparer;
 use Ginq\Comparer\ComparerParser;
 
-class GroupingGinq extends Ginq
+class GroupingGinq extends \Ginq
 {
     /**
      * @var mixed

--- a/src/Ginq/OrderedGinq.php
+++ b/src/Ginq/OrderedGinq.php
@@ -14,6 +14,8 @@
  * @package    Ginq
  */
 
+namespace Ginq;
+
 use Ginq\Core\Selector;
 use Ginq\Core\JoinSelector;
 use Ginq\Core\Comparer;
@@ -26,7 +28,7 @@ use Ginq\Comparer\ReverseComparer;
 use Ginq\Comparer\ProjectionComparer;
 use Ginq\Comparer\ComparerParser;
 
-class OrderedGinq extends Ginq
+class OrderedGinq extends \Ginq
 {
     /**
      * @var Comparer
@@ -59,7 +61,7 @@ class OrderedGinq extends Ginq
     public function thenBy($orderingKeySelector = null, $comparer = null)
     {
         if (is_null($orderingKeySelector)) {
-            $orderingKeySelector = Ginq::VALUE_OF;
+            $orderingKeySelector = \Ginq::VALUE_OF;
         }
         $orderingKeySelector = SelectorParser::parse($orderingKeySelector);
         $comparer = ComparerParser::parse($comparer);
@@ -76,7 +78,7 @@ class OrderedGinq extends Ginq
     public function thenByDesc($orderingKeySelector = null, $comparer = null)
     {
         if (is_null($orderingKeySelector)) {
-            $orderingKeySelector = Ginq::VALUE_OF;
+            $orderingKeySelector = \Ginq::VALUE_OF;
         }
         $orderingKeySelector = SelectorParser::parse($orderingKeySelector);
         $comparer = ComparerParser::parse($comparer);


### PR DESCRIPTION
require_once を相対パスでやるのはまずいので、いっそのこと名前空間の中に入れてオートロードに任せるのがいいと思ったけどどう? 他のライブラリと混ぜて使うとき、名前空間のルートにはGinqクラスしかないというのが綺麗だから。
