### PR TITLE
chore: lead to v0.2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ composer.json:
 ```json
 {
     "require": {
-        "ginq/ginq": "~0.2.3"
+        "ginq/ginq": "~0.2.4"
     }
 }
 ```


### PR DESCRIPTION
README.md に従ってインストールすると最新でない v0.2.3 が入り、
PHP7.4上で稼働させたときに `Trying to access array offset on value of type null` で
落ちることがあるのでアップデートしてほしいです